### PR TITLE
feat: fit map to screen and add action dock

### DIFF
--- a/src/components/ActionDock.tsx
+++ b/src/components/ActionDock.tsx
@@ -1,0 +1,21 @@
+'use client';
+type Props = {
+  visible: boolean;
+  onSet: (state: 'lived' | 'visited' | 'passed' | 'unvisited') => void;
+  onAddPhoto: () => void;
+};
+export default function ActionDock({ visible, onSet, onAddPhoto }: Props) {
+  if (!visible) return null;
+  return (
+    <div style={{ position: 'absolute', left: 12, bottom: 12, zIndex: 90, pointerEvents: 'auto' }}>
+      <div className="flex gap-2 flex-wrap">
+        <button data-state="lived" className="rounded px-3 py-1 border" onClick={() => onSet('lived')}>住んでいた</button>
+        <button data-state="visited" className="rounded px-3 py-1 border" onClick={() => onSet('visited')}>訪れた</button>
+        <button data-state="passed" className="rounded px-3 py-1 border" onClick={() => onSet('passed')}>通り過ぎた</button>
+        <button data-state="unvisited" className="rounded px-3 py-1 border" onClick={() => onSet('unvisited')}>未訪問</button>
+        <button className="rounded px-3 py-1 border" onClick={onAddPhoto}>思い出の写真を追加</button>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/JapanMapInteractive.tsx
+++ b/src/components/JapanMapInteractive.tsx
@@ -4,11 +4,14 @@ import MapViewport from './MapViewport';
 import { usePrefInteract } from '@/hooks/usePrefInteract';
 import HoverLabel from './HoverLabel';
 import ClickPopover from './ClickPopover';
+import ActionDock from './ActionDock';
 
 export default function JapanMapInteractive(props:{
   renderMap:()=>React.ReactNode;
   renderClickContent:(code:string)=>React.ReactNode;
   onOpenWindow:(code:string, initial:{left:number;top:number})=>void;
+  onSetState:(code:string, st:'lived'|'visited'|'passed'|'unvisited')=>void;
+  onAddPhoto:(code:string)=>void;
 }){
   const hostRef = useRef<HTMLDivElement>(null);
   const [overlayEl, setOverlayEl] = useState<HTMLDivElement|null>(null);
@@ -39,9 +42,14 @@ export default function JapanMapInteractive(props:{
       overlayChildren={
         <>
           <HoverLabel code={hover.code} label={hover.label} pt={hoverPt}/>
-          <ClickPopover open={clickAt.open} pt={clickAt.pt} onClose={()=>setClickAt(s=>({...s,open:false}))}>
+          <ClickPopover open={!!clickAt.open} pt={clickAt.pt} onClose={()=>setClickAt(s=>({...s,open:false}))}>
             {clickAt.code ? props.renderClickContent(clickAt.code) : null}
           </ClickPopover>
+          <ActionDock
+            visible={!!clickAt.code}
+            onSet={(st)=> clickAt.code && props.onSetState(clickAt.code, st)}
+            onAddPhoto={()=> clickAt.code && props.onAddPhoto(clickAt.code)}
+          />
         </>
       }
     >


### PR DESCRIPTION
## Summary
- compute union of `[data-pref]` elements to fit map and treat that scale as minimum
- add ActionDock overlay for visited/passed/photo actions
- integrate dock and popovers into interactive map

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689591cff244832ca201bee7280d78ec