### PR TITLE
feat: add interactive Japan map

### DIFF
--- a/src/components/JapanMap.tsx
+++ b/src/components/JapanMap.tsx
@@ -1,44 +1,67 @@
 'use client';
-import React from 'react';
-import type { Memory, VisitStatus } from '../types';
+import type { Memory, Prefecture, VisitStatus } from '@/types';
 import { prefectures } from '../data/prefectures';
 
-interface JapanMapProps {
+type Props = {
   memories: Memory[];
-}
-
-const statusColors: Record<VisitStatus, string> = {
-  unvisited: '#E2E8F0', // slate-200
-  passed_through: '#bae6fd', // sky-200
-  visited: '#6ee7b7', // emerald-300
-  lived: '#fca5a5', // red-400
+  onPrefectureClick: (pref: Prefecture, event: React.MouseEvent<SVGPathElement>) => void;
+  onPrefectureHover: (name: string, event: React.MouseEvent<SVGPathElement>) => void;
+  onMouseLeave: () => void;
+  onMapBackgroundClick?: () => void;
 };
 
-export default function JapanMap({ memories }: JapanMapProps) {
+const statusColors: Record<VisitStatus, string> = {
+  unvisited: '#e5e7eb',
+  visited: '#93c5fd',
+  passed: '#86efac',
+  lived: '#fca5a5',
+};
+
+export default function JapanMap({
+  memories,
+  onPrefectureClick,
+  onPrefectureHover,
+  onMouseLeave,
+  onMapBackgroundClick,
+}: Props) {
   const getFill = (prefectureId: string): string => {
-    const memory = memories.find(m => m.prefectureId === prefectureId);
-    const status = memory?.status || 'unvisited';
-    return statusColors[status];
+    const memory = memories.find((m) => m.prefectureId === prefectureId);
+    if (!memory) return statusColors.unvisited;
+    return statusColors[memory.status];
   };
 
   return (
-    <div className="w-full max-w-4xl sm:mx-auto rounded-box border bg-surface p-2 sm:p-4 shadow-card">
-      <svg viewBox="0 0 688 684" className="w-full h-auto">
-        {prefectures.map(p => {
-          const code = parseInt(p.id.replace('JP-', ''), 10).toString();
-          return (
-            <path
-              key={p.id}
-              data-pref={code}
-              data-name={p.name}
-              d={p.d}
-              fill={getFill(p.id)}
-              className="cursor-pointer"
-            />
-          );
-        })}
+    <div className="relative w-full h-[100vh]">
+      <svg
+        viewBox="0 0 688 684"
+        preserveAspectRatio="xMidYMid meet"
+        className="absolute inset-0 w-full h-full"
+        onMouseLeave={onMouseLeave}
+        onClick={onMapBackgroundClick}
+      >
+        <g>
+          {prefectures.map((p) => {
+            const memory = memories.find((m) => m.prefectureId === p.id);
+            const hasPhotos = !!(memory?.photos && memory.photos.length > 0);
+            return (
+              <path
+                key={p.id}
+                d={p.d}
+                fill={getFill(p.id)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onPrefectureClick(p, e);
+                }}
+                onMouseEnter={(e) => onPrefectureHover(p.name, e)}
+                style={{ transformBox: 'fill-box', transformOrigin: 'center' }}
+                className={`hover:scale-[1.03] hover:stroke-primary hover:stroke-[1.5px] hover:drop-shadow-[0_4px_8px_rgba(0,0,0,0.4)] ${
+                  hasPhotos ? 'stroke-white stroke-[1.5px]' : 'stroke-white stroke-[0.5px]'
+                }`}
+              />
+            );
+          })}
+        </g>
       </svg>
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- replace JapanMap with full interactive version
- handle prefecture click/hover/touch events on home page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689595b75e08832ca2df20a8b0bc4eb9