### PR TITLE
feat: refine map labels and action dock

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -35,7 +35,6 @@
 .pc-zoom{position:absolute;right:.75rem;top:3.5rem;z-index:70;display:flex;flex-direction:column;gap:.5rem}
 @media (pointer:coarse){.pc-zoom{display:none}}
 .pc-zoom input[type="range"].vertical{writing-mode:bt-lr;appearance:slider-vertical;height:160px;width:22px}
-[data-pref]:hover{animation:hoverPulse 1s ease-in-out infinite; stroke:#2563eb}
 :root{
   --color-lived:#10b981;
   --color-visited:#ef4444;
@@ -46,3 +45,7 @@ button[data-state="lived"]{background:var(--color-lived);color:#fff}
 button[data-state="visited"]{background:var(--color-visited);color:#fff}
 button[data-state="passed"]{background:var(--color-passed);color:#fff}
 button[data-state="unvisited"]{background:var(--color-unvisited);color:#111}
+
+[data-pref]{stroke:#fff;stroke-width:1.25;stroke-linejoin:round;stroke-linecap:round}
+@keyframes floatShadow{0%{filter:drop-shadow(0 0 0 rgba(0,0,0,.0))}50%{filter:drop-shadow(0 6px 10px rgba(0,0,0,.25))}100%{filter:drop-shadow(0 0 0 rgba(0,0,0,.0))}}
+[data-pref]:hover{animation:floatShadow 1.1s ease-in-out infinite}

--- a/src/components/FloatingActionDock.tsx
+++ b/src/components/FloatingActionDock.tsx
@@ -9,14 +9,14 @@ type Props={
 export default function FloatingActionDock({open,pt,onSet,onAddPhoto,onClose}:Props){
   if(!open) return null;
   return (
-    <div style={{position:'fixed',left:Math.max(8,pt.x+12),top:Math.max(8,pt.y+12),zIndex:1000}} className="rounded-xl border-2 border-black/60 bg-white px-2 py-2 shadow-lg">
-      <div className="flex items-center gap-2">
-        <button data-state="lived" className="rounded px-3 py-1 border-2 border-black/60" onClick={()=>onSet('lived')}>住んでいた</button>
+    <div style={{position:'fixed',left:Math.max(8,pt.x+12),top:Math.max(8,pt.y+12),zIndex:1000}} className="rounded-xl border-2 border-black/60 bg-white px-3 py-2 shadow-lg">
+      <div className="grid grid-cols-3 gap-2">
+        <button data-state="lived" className="rounded px-3 py-1 border-2 border-black/60" onClick={()=>onSet('lived')}>住んだ</button>
         <button data-state="visited" className="rounded px-3 py-1 border-2 border-black/60" onClick={()=>onSet('visited')}>訪れた</button>
-        <button data-state="passed" className="rounded px-3 py-1 border-2 border-black/60" onClick={()=>onSet('passed')}>通り過ぎた</button>
         <button data-state="unvisited" className="rounded px-3 py-1 border-2 border-black/60" onClick={()=>onSet('unvisited')}>未訪問</button>
-        <button className="rounded px-3 py-1 border-2 border-black/60 bg-white" onClick={onAddPhoto}>思い出の写真を追加</button>
-        <button className="rounded px-2 py-1 border-2 border-black/60 bg-white" onClick={onClose}>×</button>
+        <button data-state="passed" className="rounded px-3 py-1 border-2 border-black/60" onClick={()=>onSet('passed')}>通り過ぎた</button>
+        <button className="rounded px-3 py-1 border-2 border-black/60 bg-white" onClick={onAddPhoto}>写真を追加</button>
+        <button className="rounded px-3 py-1 border-2 border-black/60 bg-white" onClick={onClose}>×</button>
       </div>
     </div>
   );

--- a/src/components/JapanMap.tsx
+++ b/src/components/JapanMap.tsx
@@ -1,7 +1,7 @@
 'use client';
 import type { Memory, Prefecture, VisitStatus } from '@/types';
 import { prefectures } from '../data/prefectures';
-
+ 
 type Props = {
   memories: Memory[];
   onPrefectureClick: (pref: Prefecture, event: React.MouseEvent<SVGPathElement>) => void;
@@ -10,11 +10,15 @@ type Props = {
   onMapBackgroundClick?: () => void;
 };
 
+const PREF_JP: Record<string, string> = {
+  '1':'北海道','2':'青森県','3':'岩手県','4':'宮城県','5':'秋田県','6':'山形県','7':'福島県','8':'茨城県','9':'栃木県','10':'群馬県','11':'埼玉県','12':'千葉県','13':'東京都','14':'神奈川県','15':'新潟県','16':'富山県','17':'石川県','18':'福井県','19':'山梨県','20':'長野県','21':'岐阜県','22':'静岡県','23':'愛知県','24':'三重県','25':'滋賀県','26':'京都府','27':'大阪府','28':'兵庫県','29':'奈良県','30':'和歌山県','31':'鳥取県','32':'島根県','33':'岡山県','34':'広島県','35':'山口県','36':'徳島県','37':'香川県','38':'愛媛県','39':'高知県','40':'福岡県','41':'佐賀県','42':'長崎県','43':'熊本県','44':'大分県','45':'宮崎県','46':'鹿児島県','47':'沖縄県'
+};
+
 const statusColors: Record<VisitStatus, string> = {
   lived: '#10b981',
   visited: '#ef4444',
   passed: '#60a5fa',
-  unvisited: '#d1d5db',
+  unvisited: '#d1d5db'
 };
 
 export default function JapanMap({
@@ -25,9 +29,10 @@ export default function JapanMap({
   onMapBackgroundClick,
 }: Props) {
   const getFill = (prefectureId: string): string => {
-    const memory = memories.find((m) => m.prefectureId === prefectureId);
-    if (!memory) return statusColors.unvisited;
-    return statusColors[memory.status];
+    const m = memories.find(x => x.prefectureId === prefectureId);
+    if (!m) return statusColors.unvisited;
+    const k = m.status as keyof typeof statusColors;
+    return statusColors[k] ?? statusColors.unvisited;
   };
 
   return (
@@ -46,13 +51,13 @@ export default function JapanMap({
                 key={p.id}
                 d={p.d}
                 data-pref={p.id}
-                data-name={p.name}
+                data-name={PREF_JP[p.id]}
                 fill={getFill(p.id)}
-                onClick={(e)=>{ e.stopPropagation(); onPrefectureClick(p, e); }}
-                onMouseEnter={(e)=> onPrefectureHover(p.name, e)}
-                onMouseMove={(e)=> onPrefectureHover(p.name, e)}
-                style={{ transformBox:'fill-box', transformOrigin:'center' }}
-                className="stroke-white hover:stroke-primary hover:stroke-[1.5px]"
+                onClick={(e) => { e.stopPropagation(); onPrefectureClick(p, e); }}
+                onMouseEnter={(e) => onPrefectureHover(PREF_JP[p.id], e)}
+                onMouseMove={(e) => onPrefectureHover(PREF_JP[p.id], e)}
+                style={{ transformBox: 'fill-box', transformOrigin: 'center' }}
+                className="stroke-white"
               />
             );
           })}


### PR DESCRIPTION
## Summary
- ensure map uses kanji prefecture labels and consistent status colors
- arrange action dock buttons into two rows matching map color tokens
- soften hover effect with floating shadow instead of blue stroke

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895bbdb1234832cb288691adb7aad81