### PR TITLE
Add passed visit status and fix map color mapping

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -179,7 +179,7 @@ export default function Home() {
     prefectureId: string,
     status: 'lived' | 'visited' | 'passed' | 'unvisited',
   ) => {
-    const st: VisitStatus = status === 'passed' ? 'passed_through' : status;
+    const st: VisitStatus = status;
     return updateMemoryStatus(prefectureId, st);
   };
 

--- a/src/components/GalleryView.tsx
+++ b/src/components/GalleryView.tsx
@@ -42,7 +42,7 @@ const GalleryView: React.FC<GalleryViewProps> = ({ prefecture, onBackToMap, onAd
         >
           <option value="lived">住んでいた</option>
           <option value="visited">訪れた</option>
-          <option value="passed_through">通り過ぎた</option>
+          <option value="passed">通り過ぎた</option>
           <option value="unvisited">未訪問</option>
         </select>
       </div>

--- a/src/components/JapanMap.tsx
+++ b/src/components/JapanMap.tsx
@@ -29,10 +29,9 @@ export default function JapanMap({
   onMapBackgroundClick,
 }: Props) {
   const getFill = (prefectureId: string): string => {
-    const m = memories.find(x => x.prefectureId === prefectureId);
+    const m = memories.find(v => v.prefectureId === prefectureId);
     if (!m) return statusColors.unvisited;
-    const k = m.status as keyof typeof statusColors;
-    return statusColors[k] ?? statusColors.unvisited;
+    return statusColors[m.status] ?? statusColors.unvisited;
   };
 
   return (

--- a/src/components/JapanMapInteractive.tsx
+++ b/src/components/JapanMapInteractive.tsx
@@ -29,7 +29,7 @@ export default function JapanMapInteractive(props:{
     const or = overlayEl.getBoundingClientRect();
     const pt = { x: viewportPt.x - or.left, y: viewportPt.y - or.top };
     setClickAt({ open:true, code, pt });
-    props.onOpenWindow(code, pt);
+    props.onOpenWindow(code, { left: pt.x, top: pt.y });
   });
 
   const hoverPt = toOverlay(hover.pt);

--- a/src/components/PrefectureDetailModal.tsx
+++ b/src/components/PrefectureDetailModal.tsx
@@ -49,7 +49,7 @@ export default function PrefectureDetailModal({ prefecture, isOpen, onClose, onA
 
   const StatusButton = ({ status, label }: { status: VisitStatus; label: string }) => {
     const isActive = currentStatus === status;
-    const dataState = status === 'passed_through' ? 'passed' : status;
+    const dataState = status;
 
     return (
       <button
@@ -80,7 +80,7 @@ export default function PrefectureDetailModal({ prefecture, isOpen, onClose, onA
           <div className="grid grid-cols-2 gap-3">
             <StatusButton status="visited" label="訪れた" />
             <StatusButton status="lived" label="住んでいた" />
-            <StatusButton status="passed_through" label="通り過ぎた" />
+            <StatusButton status="passed" label="通り過ぎた" />
             <StatusButton status="unvisited" label="未訪問" />
           </div>
           <div className="border-t border-background"></div>

--- a/src/hooks/usePrefInteract.ts
+++ b/src/hooks/usePrefInteract.ts
@@ -3,7 +3,7 @@ import { RefObject, useEffect, useRef, useState } from 'react';
 
 const N: Record<string, string> = {'1':'北海道','2':'青森県','3':'岩手県','4':'宮城県','5':'秋田県','6':'山形県','7':'福島県','8':'茨城県','9':'栃木県','10':'群馬県','11':'埼玉県','12':'千葉県','13':'東京都','14':'神奈川県','15':'新潟県','16':'富山県','17':'石川県','18':'福井県','19':'山梨県','20':'長野県','21':'岐阜県','22':'静岡県','23':'愛知県','24':'三重県','25':'滋賀県','26':'京都府','27':'大阪府','28':'兵庫県','29':'奈良県','30':'和歌山県','31':'鳥取県','32':'島根県','33':'岡山県','34':'広島県','35':'山口県','36':'徳島県','37':'香川県','38':'愛媛県','39':'高知県','40':'福岡県','41':'佐賀県','42':'長崎県','43':'熊本県','44':'大分県','45':'宮崎県','46':'鹿児島県','47':'沖縄県'};
 
-export function usePrefInteract(container: RefObject<HTMLElement>, onOpen: (code: string, viewportPt: { x: number; y: number }) => void) {
+export function usePrefInteract(container: RefObject<HTMLElement | null>, onOpen: (code: string, viewportPt: { x: number; y: number }) => void) {
   const [hover, setHover] = useState<{ code: string | null; label: string | null; pt: { x: number; y: number } }>({ code: null, label: null, pt: { x: 0, y: 0 } });
   const lastEl = useRef<HTMLElement | null>(null);
   const primed = useRef<{ code: string; ts: number } | null>(null);

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,7 @@ export interface Photo {
 }
 
 // Define the possible visit statuses
-export type VisitStatus = 'lived' | 'visited' | 'passed_through' | 'unvisited';
+export type VisitStatus = 'unvisited' | 'visited' | 'passed' | 'lived';
 
 export interface Memory {
   prefectureId: string;


### PR DESCRIPTION
## Summary
- include `passed` in `VisitStatus` and clean up `statusColors`
- treat unknown prefecture statuses as unvisited in map rendering
- replace legacy `passed_through` status with `passed` across the app and fix map interaction types

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6895d040383c832c9086fb5f86f50142