### PR TITLE
feat: refine action dock layout and hover labels

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -49,3 +49,4 @@ button[data-state="unvisited"]{background:var(--color-unvisited);color:#111}
 [data-pref]{stroke:#fff;stroke-width:1.25;stroke-linejoin:round;stroke-linecap:round}
 @keyframes floatShadow{0%{filter:drop-shadow(0 0 0 rgba(0,0,0,.0))}50%{filter:drop-shadow(0 6px 10px rgba(0,0,0,.25))}100%{filter:drop-shadow(0 0 0 rgba(0,0,0,.0))}}
 [data-pref]:hover{animation:floatShadow 1.1s ease-in-out infinite}
+[data-pref]:hover{animation:floatShadow 1.1s ease-in-out infinite; stroke:transparent}

--- a/src/components/FloatingActionDock.tsx
+++ b/src/components/FloatingActionDock.tsx
@@ -15,7 +15,10 @@ export default function FloatingActionDock({open,pt,onSet,onAddPhoto,onClose}:Pr
         <button data-state="visited" className="rounded px-3 py-1 border-2 border-black/60" onClick={()=>onSet('visited')}>訪れた</button>
         <button data-state="unvisited" className="rounded px-3 py-1 border-2 border-black/60" onClick={()=>onSet('unvisited')}>未訪問</button>
         <button data-state="passed" className="rounded px-3 py-1 border-2 border-black/60" onClick={()=>onSet('passed')}>通り過ぎた</button>
+        <button className="rounded px-3 py-1 border-2 border-black/60 bg-white">行きたい</button>
         <button className="rounded px-3 py-1 border-2 border-black/60 bg-white" onClick={onAddPhoto}>写真を追加</button>
+      </div>
+      <div className="flex justify-end mt-2">
         <button className="rounded px-3 py-1 border-2 border-black/60 bg-white" onClick={onClose}>×</button>
       </div>
     </div>

--- a/src/components/JapanMap.tsx
+++ b/src/components/JapanMap.tsx
@@ -56,7 +56,6 @@ export default function JapanMap({
                 onClick={(e) => { e.stopPropagation(); onPrefectureClick(p, e); }}
                 onMouseEnter={(e) => onPrefectureHover(PREF_JP[p.id], e)}
                 onMouseMove={(e) => onPrefectureHover(PREF_JP[p.id], e)}
-                style={{ transformBox: 'fill-box', transformOrigin: 'center' }}
                 className="stroke-white"
               />
             );


### PR DESCRIPTION
## Summary
- adjust floating action dock to two-row layout and separate close button
- ensure map hover uses Japanese prefecture names from id mapping
- remove blue outline on map hover using transparent stroke

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx vitest run` *(fails: browserType.launch executable doesn't exist; requires Playwright browsers)*
- `npx playwright install` *(fails: download error 403)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895c0b2abc8832c93c84b5855de1038