### PR TITLE
feat: surface hover names and photo presence

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -188,7 +188,9 @@ export default function Home() {
     if (pref) handleAddPhotoRequest(pref);
   };
 
-  const hasPhotos = selectedPrefecture ? !!(memories.find(m=>m.prefectureId===selectedPrefecture.id)?.photos?.length) : false;
+  const hasPhotos = selectedPrefecture
+    ? !!(memories.find((m) => m.prefectureId === selectedPrefecture.id)?.photos?.length)
+    : false;
 
   return (
     <main className="relative flex min-h-screen flex-col bg-background">


### PR DESCRIPTION
## Summary
- compute `hasPhotos` from current selection and pass to floating action dock
- show hovered prefecture name using `HoverLabelFixed`
- drop unused fixed bottom panel

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895e29b6030832ca60316a9d849d925