### PR TITLE
feat: enhance photo viewer and user profiles

### DIFF
--- a/src/app/api/drive/upload/route.ts
+++ b/src/app/api/drive/upload/route.ts
@@ -157,7 +157,7 @@ export async function POST(req: NextRequest) {
       }
 
       const { id, name, webViewLink } = await driveRes.json();
-      uploaded.push({ id, name, url: webViewLink });
+      uploaded.push({ id, name, url: webViewLink, createdAt: new Date().toISOString(), likes: 0 });
     }
 
     return NextResponse.json({ photos: uploaded });

--- a/src/app/user/[userId]/page.tsx
+++ b/src/app/user/[userId]/page.tsx
@@ -1,0 +1,43 @@
+'use client';
+import { useEffect, useState } from 'react';
+import JapanMap from '@/components/JapanMap';
+import { firestoreService } from '@/services/firestoreService';
+import type { Memory } from '@/types';
+
+export default function UserProfilePage({ params }: { params: { userId: string } }) {
+  const { userId } = params;
+  const [memories, setMemories] = useState<Memory[]>([]);
+
+  useEffect(() => {
+    firestoreService.getMemories(userId).then(setMemories);
+  }, [userId]);
+
+  const visitedCount = memories.filter(m => m.status !== 'unvisited').length;
+
+  const share = () => {
+    const text = `私は${visitedCount}/47都道府県を訪れました！`;
+    const url = typeof window !== 'undefined' ? window.location.href : '';
+    window.open(`https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}`);
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">プロフィール</h1>
+      <p>{visitedCount}/47 都道府県</p>
+      <button onClick={share} className="rounded bg-blue-500 px-4 py-2 text-white">旅の軌跡をシェアする</button>
+      <div className="h-96">
+        <JapanMap
+          memories={memories}
+          onPrefectureClick={() => {}}
+          onPrefectureHover={() => {}}
+          onMouseLeave={() => {}}
+        />
+      </div>
+      <div className="grid grid-cols-3 gap-2">
+        {memories.flatMap(m => m.photos || []).map(photo => (
+          <img key={photo.id} src={photo.url} alt={photo.name} className="h-24 w-full object-cover" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/PhotoViewer.tsx
+++ b/src/components/PhotoViewer.tsx
@@ -1,19 +1,46 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import type { Photo } from '@/types';
+import { firestoreService } from '@/services/firestoreService';
 
 interface Props {
+  userId: string;
+  prefectureId: string;
   photos: Photo[];
   initialIndex: number;
   onClose: () => void;
 }
-
-export default function PhotoViewer({ photos, initialIndex, onClose }: Props) {
+export default function PhotoViewer({ userId, prefectureId, photos, initialIndex, onClose }: Props) {
   const [index, setIndex] = useState(initialIndex);
+  const [caption, setCaption] = useState(photos[initialIndex]?.caption || '');
+  const [likes, setLikes] = useState(photos[initialIndex]?.likes || 0);
+
+  useEffect(() => {
+    setCaption(photos[index]?.caption || '');
+    setLikes(photos[index]?.likes || 0);
+  }, [index, photos]);
+
+  const saveCaption = async () => {
+    if (!userId) return;
+    await firestoreService.updatePhotoCaption(userId, prefectureId, photos[index].id, caption);
+    photos[index].caption = caption;
+  };
+
+  const likePhoto = async () => {
+    const newLikes = (likes || 0) + 1;
+    setLikes(newLikes);
+    photos[index].likes = newLikes;
+    await firestoreService.updatePhotoLikes(userId, prefectureId, photos[index].id, newLikes);
+  };
 
   const next = () => setIndex(prev => (prev + 1) % photos.length);
   const prev = () => setIndex(prev => (prev - 1 + photos.length) % photos.length);
+
+  const photo = photos[index];
+  const createdAt = photo.createdAt instanceof Date
+    ? photo.createdAt.toISOString()
+    : photo.createdAt;
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/90">
@@ -31,8 +58,8 @@ export default function PhotoViewer({ photos, initialIndex, onClose }: Props) {
         ‹
       </button>
       <img
-        src={photos[index].url}
-        alt={photos[index].name}
+        src={photo.url}
+        alt={photo.name}
         className="max-h-full max-w-full object-contain"
       />
       <button
@@ -42,6 +69,25 @@ export default function PhotoViewer({ photos, initialIndex, onClose }: Props) {
       >
         ›
       </button>
+      <div className="absolute bottom-6 left-6 text-white">
+        <p>{photo.name}</p>
+        {createdAt && <p className="text-sm">{createdAt}</p>}
+        <button onClick={likePhoto} className="mt-2 text-lg">❤️ {likes}</button>
+      </div>
+      <div className="absolute bottom-6 right-6 flex flex-col">
+        <input
+          value={caption}
+          onChange={e => setCaption(e.target.value)}
+          placeholder="キャプションを入力"
+          className="rounded p-1 text-black"
+        />
+        <button
+          onClick={saveCaption}
+          className="mt-2 rounded bg-white/80 px-2 py-1 text-black"
+        >
+          保存
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/PrefectureDetailModal.tsx
+++ b/src/components/PrefectureDetailModal.tsx
@@ -14,7 +14,7 @@ interface Props {
 }
 
 export default function PrefectureDetailModal({ prefecture, isOpen, onClose, onAddPhoto, position }: Props) {
-  const { memories, updateMemoryStatus } = useGlobalContext();
+  const { user, memories, updateMemoryStatus } = useGlobalContext();
   const [viewerIndex, setViewerIndex] = useState<number | null>(null);
 
   const getModalStyle = () => {
@@ -134,6 +134,8 @@ export default function PrefectureDetailModal({ prefecture, isOpen, onClose, onA
       </div>
       {viewerIndex !== null && photos.length > 0 && (
         <PhotoViewer
+          userId={user?.uid || ''}
+          prefectureId={prefecture.id}
           photos={photos}
           initialIndex={viewerIndex}
           onClose={() => setViewerIndex(null)}

--- a/src/services/firestoreService.ts
+++ b/src/services/firestoreService.ts
@@ -48,5 +48,35 @@ export const firestoreService = {
 
     await setDoc(memoryDocRef, updatedMemory, { merge: true });
   },
+
+  // Update caption for a specific photo within a memory
+  updatePhotoCaption: async (
+    userId: string,
+    prefectureId: string,
+    photoId: string,
+    caption: string,
+  ): Promise<void> => {
+    const memoryDocRef = doc(db, 'users', userId, 'memories', prefectureId);
+    const docSnap = await getDoc(memoryDocRef);
+    if (!docSnap.exists()) return;
+    const memory = docSnap.data() as Memory;
+    const updatedPhotos = memory.photos.map(p => (p.id === photoId ? { ...p, caption } : p));
+    await setDoc(memoryDocRef, { ...memory, photos: updatedPhotos }, { merge: true });
+  },
+
+  // Update likes for a specific photo
+  updatePhotoLikes: async (
+    userId: string,
+    prefectureId: string,
+    photoId: string,
+    likes: number,
+  ): Promise<void> => {
+    const memoryDocRef = doc(db, 'users', userId, 'memories', prefectureId);
+    const docSnap = await getDoc(memoryDocRef);
+    if (!docSnap.exists()) return;
+    const memory = docSnap.data() as Memory;
+    const updatedPhotos = memory.photos.map(p => (p.id === photoId ? { ...p, likes } : p));
+    await setDoc(memoryDocRef, { ...memory, photos: updatedPhotos }, { merge: true });
+  },
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { Timestamp } from 'firebase/firestore';
+
 export interface User {
   uid: string;
   displayName: string | null;
@@ -14,6 +16,9 @@ export interface Photo {
   id: string;
   url: string;
   name: string;
+  createdAt?: string | Timestamp;
+  caption?: string;
+  likes?: number;
 }
 
 // Define the possible visit statuses


### PR DESCRIPTION
## Summary
- extend photo model with metadata, captions, and likes
- allow updating photo captions and likes in Firestore
- enrich photo viewer UI and add basic user profile page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f45f0f9d4832c94faad80aac117dc