### PR TITLE
feat: add collapsible sidebar

### DIFF
--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React from 'react';
-import Header from '@/components/Header';
 import { useGlobalContext } from '@/context/AppContext';
 import { prefectures } from '@/data/prefectures';
 import type { Photo } from '@/types';
@@ -39,7 +38,6 @@ export default function GalleryPage() {
 
   return (
     <main className="min-h-screen bg-background">
-      <Header />
       <div className="container mx-auto space-y-8 p-4">
         {prefectures.map(pref => {
           const memory = memories.find(m => m.prefectureId === pref.id);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
-import { AuthProvider } from "@/context/AuthContext";
 import { AppProvider } from "@/context/AppContext";
-import Auth from "@/components/Auth";
-import LoginFixedTopRight from "@/components/LoginFixedTopRight";
+import Sidebar from "@/components/Sidebar";
 
 export const metadata: Metadata = {
   title: "地図コレ",
@@ -24,14 +22,17 @@ export default function RootLayout({
         />
       </head>
       <body className="bg-background text-text-primary">
-        <AuthProvider>
-          <AppProvider>
-            <LoginFixedTopRight>
-              <Auth />
-            </LoginFixedTopRight>
-            {children}
-          </AppProvider>
-        </AuthProvider>
+        <AppProvider>
+          <div className="flex h-screen overflow-hidden">
+            {/* PC (md以上) でのみSidebarを表示 */}
+            <div className="hidden md:block">
+              <Sidebar />
+            </div>
+            <main className="flex-1 overflow-y-auto">
+              {children}
+            </main>
+          </div>
+        </AppProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,6 @@ import LoginModal from '@/components/LoginModal';
 import MergeConflictModal from '@/components/MergeConflictModal';
 import FloatingActionDock from '@/components/FloatingActionDock';
 import HoverLabelFixed from '@/components/HoverLabelFixed';
-import Header from '@/components/Header';
 import type { Prefecture, VisitStatus } from '@/types';
 import { useGlobalContext } from '@/context/AppContext';
 import { prefectures } from '@/data/prefectures';
@@ -186,8 +185,6 @@ export default function Home() {
 
   return (
     <main className="relative flex min-h-screen flex-col bg-background">
-      <Header onAddMemory={openAddModal} />
-
       <div className="container mx-auto flex flex-grow flex-col items-center justify-center p-4">
         <JapanMap
           memories={memories}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+import { useGlobalContext } from '@/context/AppContext';
+
+export default function Sidebar() {
+  const { user, signIn, signOut } = useGlobalContext();
+  const [isCollapsed, setIsCollapsed] = useState(false);
+
+  return (
+    <aside
+      className={`bg-surface h-full text-text-primary shadow-lg transition-all duration-300 ${isCollapsed ? 'w-20' : 'w-64'}`}
+    >
+      <nav className="h-full flex flex-col p-4">
+        <button
+          onClick={() => setIsCollapsed(!isCollapsed)}
+          className="mb-4 self-end p-2 rounded-lg hover:bg-background"
+        >
+          {isCollapsed ? '開く' : '畳む'}
+        </button>
+
+        <ul className="space-y-2 flex-grow">
+          <li>
+            <Link href="/" className="flex items-center p-2 rounded-lg hover:bg-background">
+              <span className="text-2xl">🗺️</span>
+              {!isCollapsed && <span className="ml-3 font-semibold">地図</span>}
+            </Link>
+          </li>
+          <li>
+            <Link href="/gallery" className="flex items-center p-2 rounded-lg hover:bg-background">
+              <span className="text-2xl">🖼️</span>
+              {!isCollapsed && <span className="ml-3 font-semibold">ギャラリー</span>}
+            </Link>
+          </li>
+          {/**
+          <li>
+            <Link href="/settings" className="flex items-center p-2 rounded-lg hover:bg-background">
+              <span className="text-2xl">⚙️</span>
+              {!isCollapsed && <span className="ml-3 font-semibold">設定</span>}
+            </Link>
+          </li>
+          */}
+        </ul>
+
+        <div className="border-t border-background pt-4">
+          {user ? (
+            <button
+              onClick={signOut}
+              className="flex items-center w-full p-2 rounded-lg hover:bg-background"
+            >
+              {user.photoURL ? (
+                <img src={user.photoURL} alt="avatar" className="w-8 h-8 rounded-full" />
+              ) : (
+                <span className="text-2xl">👤</span>
+              )}
+              {!isCollapsed && <span className="ml-3 text-sm">サインアウト</span>}
+            </button>
+          ) : (
+            <button
+              onClick={signIn}
+              className="flex items-center w-full p-2 rounded-lg hover:bg-background"
+            >
+              <span className="text-2xl">🚪</span>
+              {!isCollapsed && <span className="ml-3 font-semibold">ログイン</span>}
+            </button>
+          )}
+        </div>
+      </nav>
+    </aside>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add collapsible Sidebar component with navigation and auth actions
- integrate Sidebar into layout and remove top header
- clean up outdated Header usage on pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f4aa30814832c8137e70bb150f06c