### PR TITLE
feat: add trip recording mode with share animation

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -31,6 +31,15 @@
 .map-container{position:relative;overflow:hidden;touch-action:none;user-select:none}
 .map-stage{will-change:transform;transform-origin:0 0}
 .map-overlay{position:absolute;inset:0;z-index:60;pointer-events:none}
+
+@keyframes flashHighlight {
+  0% { fill: #fff; }
+  50% { fill: #fef08a; }
+  100% { fill: var(--color-visited); }
+}
+.flash-highlight {
+  animation: flashHighlight 1s ease-out forwards;
+}
 [data-pref]{stroke:#fff;stroke-width:1.25;stroke-linejoin:round;stroke-linecap:round}
 .pc-zoom{position:absolute;right:.75rem;top:3.5rem;z-index:70;display:flex;flex-direction:column;gap:.5rem}
 @media (pointer:coarse){.pc-zoom{display:none}}

--- a/src/components/JapanMap.tsx
+++ b/src/components/JapanMap.tsx
@@ -2,13 +2,16 @@
 import type { Memory, Prefecture, VisitStatus } from '@/types';
 import { prefectures } from '../data/prefectures';
  
-type Props = {
-  memories: Memory[];
-  onPrefectureClick: (pref: Prefecture, event: React.MouseEvent<SVGPathElement>) => void;
-  onPrefectureHover: (name: string, event: React.MouseEvent<SVGPathElement>) => void;
-  onMouseLeave: () => void;
-  onMapBackgroundClick?: () => void;
-};
+  type Props = {
+    memories: Memory[];
+    onPrefectureClick: (pref: Prefecture, event: React.MouseEvent<SVGPathElement>) => void;
+    onPrefectureHover: (name: string, event: React.MouseEvent<SVGPathElement>) => void;
+    onMouseLeave: () => void;
+    onMapBackgroundClick?: () => void;
+    isRecordingTrip?: boolean;
+    selectedPrefectures?: string[];
+    flashPrefectures?: string[];
+  };
 
 const PREF_JP: Record<string, string> = {
   '1':'北海道','2':'青森県','3':'岩手県','4':'宮城県','5':'秋田県','6':'山形県','7':'福島県','8':'茨城県','9':'栃木県','10':'群馬県','11':'埼玉県','12':'千葉県','13':'東京都','14':'神奈川県','15':'新潟県','16':'富山県','17':'石川県','18':'福井県','19':'山梨県','20':'長野県','21':'岐阜県','22':'静岡県','23':'愛知県','24':'三重県','25':'滋賀県','26':'京都府','27':'大阪府','28':'兵庫県','29':'奈良県','30':'和歌山県','31':'鳥取県','32':'島根県','33':'岡山県','34':'広島県','35':'山口県','36':'徳島県','37':'香川県','38':'愛媛県','39':'高知県','40':'福岡県','41':'佐賀県','42':'長崎県','43':'熊本県','44':'大分県','45':'宮崎県','46':'鹿児島県','47':'沖縄県'
@@ -21,13 +24,16 @@ const statusColors: Record<VisitStatus, string> = {
   unvisited: '#d1d5db'
 };
 
-export default function JapanMap({
-  memories,
-  onPrefectureClick,
-  onPrefectureHover,
-  onMouseLeave,
-  onMapBackgroundClick,
-}: Props) {
+  export default function JapanMap({
+    memories,
+    onPrefectureClick,
+    onPrefectureHover,
+    onMouseLeave,
+    onMapBackgroundClick,
+    isRecordingTrip = false,
+    selectedPrefectures = [],
+    flashPrefectures = [],
+  }: Props) {
   const getFill = (prefectureId: string): string => {
     const m = memories.find(x => x.prefectureId === prefectureId);
     if (!m) return statusColors.unvisited;
@@ -46,21 +52,24 @@ export default function JapanMap({
         <g>
           {prefectures.map((p) => {
             return (
-              <path
-                key={p.id}
-                d={p.d}
-                data-pref={p.id}
-                data-name={PREF_JP[p.id]}
-                fill={getFill(p.id)}
-                onClick={(e) => { e.stopPropagation(); onPrefectureClick(p, e); }}
-                onMouseEnter={(e) => onPrefectureHover(PREF_JP[p.id], e)}
-                onMouseMove={(e) => onPrefectureHover(PREF_JP[p.id], e)}
-                className="stroke-white"
-              />
-            );
-          })}
-        </g>
-      </svg>
-    </div>
-  );
-}
+                <path
+                  key={p.id}
+                  d={p.d}
+                  data-pref={p.id}
+                  data-name={PREF_JP[p.id]}
+                  fill={getFill(p.id)}
+                  onClick={(e) => { e.stopPropagation(); onPrefectureClick(p, e); }}
+                  onMouseEnter={(e) => onPrefectureHover(PREF_JP[p.id], e)}
+                  onMouseMove={(e) => onPrefectureHover(PREF_JP[p.id], e)}
+                  className={`stroke-white transition-transform ${
+                    isRecordingTrip && selectedPrefectures.includes(p.id) ? 'pref-wiggle scale-[1.02]' : ''
+                  } ${flashPrefectures.includes(p.id) ? 'flash-highlight' : ''}`}
+                  style={{ transformOrigin: 'center' }}
+                />
+              );
+            })}
+          </g>
+        </svg>
+      </div>
+    );
+  }

--- a/src/components/TripShareModal.tsx
+++ b/src/components/TripShareModal.tsx
@@ -1,0 +1,61 @@
+'use client';
+import React, { useEffect, useMemo, useState } from 'react';
+import JapanMap from './JapanMap';
+import type { Memory } from '@/types';
+
+type Props = {
+  isOpen: boolean;
+  memories: Memory[];
+  newlyVisited: string[];
+  onClose: () => void;
+};
+
+const TripShareModal: React.FC<Props> = ({ isOpen, memories, newlyVisited, onClose }) => {
+  const [showShareButtons, setShowShareButtons] = useState(false);
+
+  const previewMemories = useMemo(() => {
+    const ids = new Set(newlyVisited);
+    const base = memories.filter(m => !ids.has(m.prefectureId));
+    const added = Array.from(ids).map(id => ({
+      prefectureId: id,
+      status: 'visited',
+      photos: memories.find(m => m.prefectureId === id)?.photos || [],
+    }));
+    return [...base, ...added];
+  }, [memories, newlyVisited]);
+
+  useEffect(() => {
+    if (isOpen) {
+      setShowShareButtons(false);
+      const timer = setTimeout(() => setShowShareButtons(true), 1200);
+      return () => clearTimeout(timer);
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70">
+      <div className="relative w-full max-w-3xl rounded bg-surface p-4">
+        <button className="absolute right-2 top-2" onClick={onClose}>
+          ✕
+        </button>
+        <JapanMap
+          memories={previewMemories}
+          onPrefectureClick={() => {}}
+          onPrefectureHover={() => {}}
+          onMouseLeave={() => {}}
+          flashPrefectures={newlyVisited}
+        />
+        {showShareButtons && (
+          <div className="mt-4 flex justify-center gap-4">
+            <button className="rounded bg-blue-500 px-3 py-1 text-white">X</button>
+            <button className="rounded bg-pink-500 px-3 py-1 text-white">Instagram</button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TripShareModal;


### PR DESCRIPTION
## Summary
- add trip recording state and helpers in AppContext
- highlight selected prefectures and flash newly visited ones on share preview
- support trip sharing flow with animated preview modal

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689f4e48d540832cb2b0eb58ba23f973