### PR TITLE
fix(ui): render FloatingActionDock via portal with max z-index to escape stacking contexts

### DIFF
--- a/src/components/FloatingActionDock.tsx
+++ b/src/components/FloatingActionDock.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+import { useEffect, useRef, useState } from 'react';
+import Portal from './Portal';
+
 type Props = {
   onPaint?: () => void;
   onErase?: () => void;
@@ -9,15 +12,46 @@ type Props = {
 };
 
 export default function FloatingActionDock({ onPaint, onErase, onUndo, onRedo, onShare }: Props) {
+  const [open, setOpen] = useState(false);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: Event) => {
+      if (!panelRef.current) return;
+      if (!panelRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    const id = setTimeout(() => {
+      document.addEventListener('pointerdown', handler, true);
+    }, 0);
+    return () => {
+      clearTimeout(id);
+      document.removeEventListener('pointerdown', handler, true);
+    };
+  }, [open]);
+
   return (
-    <div className="fixed bottom-4 right-4 z-[60]">
-      <div className="rounded-2xl border bg-white/90 backdrop-blur shadow-lg p-2 flex gap-2">
-        <button onClick={onPaint} className="px-3 py-2 rounded-xl border hover:bg-neutral-50">塗る</button>
-        <button onClick={onErase} className="px-3 py-2 rounded-xl border hover:bg-neutral-50">消しゴム</button>
-        <button onClick={onUndo} className="px-3 py-2 rounded-xl border hover:bg-neutral-50">元に戻す</button>
-        <button onClick={onRedo} className="px-3 py-2 rounded-xl border hover:bg-neutral-50">やり直す</button>
-        <button onClick={onShare} className="px-3 py-2 rounded-xl bg-neutral-900 text-white hover:opacity-90">共有</button>
+    <Portal>
+      <div className="fixed inset-0 pointer-events-none z-[2147483647]">
+        <div className="absolute bottom-4 right-4 pointer-events-auto">
+          <div className="relative" ref={panelRef}>
+            <div className={`absolute bottom-14 right-0 grid gap-2 transition-all duration-200 ${open ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2 pointer-events-none'}`}>
+              <button onClick={onPaint} className="px-3 py-2 rounded-xl border bg-white/90 backdrop-blur shadow">塗る</button>
+              <button onClick={onErase} className="px-3 py-2 rounded-xl border bg-white/90 backdrop-blur shadow">消しゴム</button>
+              <button onClick={onUndo} className="px-3 py-2 rounded-xl border bg-white/90 backdrop-blur shadow">元に戻す</button>
+              <button onClick={onRedo} className="px-3 py-2 rounded-xl border bg-white/90 backdrop-blur shadow">やり直す</button>
+              <button onClick={onShare} className="px-3 py-2 rounded-xl border bg-white/90 backdrop-blur shadow">共有</button>
+            </div>
+            <button
+              onClick={() => setOpen(v => !v)}
+              className="h-12 w-12 rounded-full bg-neutral-900 text-white shadow-lg grid place-items-center"
+              aria-expanded={open}
+            >
+              ＋
+            </button>
+          </div>
+        </div>
       </div>
-    </div>
+    </Portal>
   );
 }

--- a/src/components/Portal.tsx
+++ b/src/components/Portal.tsx
@@ -1,0 +1,10 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+export default function Portal({ children }: { children: React.ReactNode }) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => { setMounted(true); }, []);
+  if (!mounted) return null;
+  return createPortal(children, document.body);
+}


### PR DESCRIPTION
## Summary
- add Portal client component rendering to document.body
- render FloatingActionDock through Portal with max z-index and delayed outside click capture

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fe099b5f4832c92e50ba7d8d8687b